### PR TITLE
Eddi repair

### DIFF
--- a/passes/ASPIS.h
+++ b/passes/ASPIS.h
@@ -7,6 +7,7 @@
 #include <llvm/IR/Instructions.h>
 #include <map>
 #include <set>
+#include <unordered_set>
 
 using namespace llvm;
 
@@ -53,6 +54,7 @@ class EDDI : public PassInfoMixin<EDDI> {
         int duplicateInstruction(Instruction &I, std::map<Value *, Value *> &DuplicatedInstructionMap, BasicBlock &ErrBB);
         bool isValueDuplicated(std::map<Value *, Value *> &DuplicatedInstructionMap, Instruction &V);
         Function *duplicateFnArgs(Function &Fn, Module &Md, std::map<Value *, Value *> &DuplicatedInstructionMap);
+        void repairBasicBlock(BasicBlock &BB, std::unordered_set<Instruction *> &ClonedInstructions);
 
     public:
         PreservedAnalyses run(Module &M,

--- a/passes/EDDI.cpp
+++ b/passes/EDDI.cpp
@@ -990,7 +990,11 @@ void EDDI::repairBasicBlock(
     // AllocaInsts are kept in the entry block's alloca region.
     // Terminators (br, ret, switch, …) must remain last.
     // None of these should be relocated
-    if (isa<PHINode>(&I) || isa<AllocaInst>(&I) || I.isTerminator())
+  
+    // if (isa<PHINode>(&I) || /*isa<AllocaInst>(&I) || */ I.isTerminator())
+    //   continue;
+
+    if (I.isTerminator())
       continue;
 
     // If this instruction belongs to the cloned set, it is a duplicate
@@ -1007,7 +1011,12 @@ void EDDI::repairBasicBlock(
   // original relative order
   Instruction *InsertPt = BB.getTerminator();
   for (Instruction *Dup : DupsInOrder) {
-    Dup->moveBefore(InsertPt);
+    if(isa<PHINode>(Dup)){
+      Dup->moveBefore(BB.getFirstNonPHI());
+    }
+    else{
+      Dup->moveBefore(InsertPt);
+    }
   }
 }
 
@@ -1175,8 +1184,8 @@ PreservedAnalyses EDDI::run(Module &Md, ModuleAnalysisManager &AM) {
         }
       }
       for (BasicBlock &BB : Fn) {
-  repairBasicBlock(BB, ClonedInstructions);
-}
+        repairBasicBlock(BB, ClonedInstructions);
+      }
 
       // insert the code for calling the error basic block in case of a mismatch
       IRBuilder<> ErrB(ErrBB);

--- a/passes/EDDI.cpp
+++ b/passes/EDDI.cpp
@@ -93,6 +93,8 @@ int EDDI::isUsedByStore(Instruction &I, Instruction &Use) {
   return 0;
 }
 
+static std::unordered_set<Instruction *> ClonedInstructions;
+
 /**
  * Clones instruction `I` and adds the pair <I, IClone> to
  * DuplicatedInstructionMap, inserting the clone right after the original.
@@ -113,6 +115,9 @@ EDDI::cloneInstr(Instruction &I,
   } // else place it right after the instruction we are working on
   else {
     IClone->insertAfter(&I);
+    
+    ClonedInstructions.insert(IClone);
+    
   }
   DuplicatedInstructionMap.insert(
       std::pair<Instruction *, Instruction *>(&I, IClone));
@@ -414,7 +419,7 @@ void EDDI::fixFuncValsPassedByReference(
 Function *EDDI::getFunctionDuplicate(Function *Fn) {
   // If Fn ends with "_dup" we have already the duplicated function.
   // If Fn is NULL, it means that we don't have a duplicate
-  if (Fn == NULL || Fn->getName().endswith("_dup")) {
+  if (Fn == NULL || Fn->getName().ends_with("_dup")) {
     return Fn;
   }
 
@@ -432,7 +437,7 @@ Function *EDDI::getFunctionDuplicate(Function *Fn) {
 Function *EDDI::getFunctionFromDuplicate(Function *Fn) {
   // If Fn ends with "_dup" we have already the duplicated function.
   // If Fn is NULL, it means that we don't have a duplicate
-  if (Fn == NULL || !Fn->getName().endswith("_dup")) {
+  if (Fn == NULL || !Fn->getName().ends_with("_dup")) {
     return Fn;
   }
 
@@ -486,8 +491,8 @@ void EDDI::duplicateGlobals(
   for (auto GV : GVars) {
     if (!isa<Function>(GV) &&
         FuncAnnotations.find(GV) != FuncAnnotations.end()) {
-      if ((FuncAnnotations.find(GV))->second.startswith("runtime_sig") ||
-          (FuncAnnotations.find(GV))->second.startswith("run_adj_sig")) {
+      if ((FuncAnnotations.find(GV))->second.starts_with("runtime_sig") ||
+          (FuncAnnotations.find(GV))->second.starts_with("run_adj_sig")) {
         continue;
       }
     }
@@ -505,13 +510,13 @@ void EDDI::duplicateGlobals(
     bool isConstant = GV->isConstant();
     bool isStruct = GV->getValueType()->isStructTy();
     bool isArray = GV->getValueType()->isArrayTy();
-    bool isPointer = GV->getValueType()->isOpaquePointerTy();
-    bool endsWithDup = GV->getName().endswith("_dup");
+    bool isPointer = GV->getValueType()->isPointerTy();
+    bool endsWithDup = GV->getName().ends_with("_dup");
     bool hasExternalLinkage = GV->isExternallyInitialized() || GV->hasExternalLinkage();
     bool isMetadataInfo = GV->getSection() == "llvm.metadata";
     bool toExclude = !isa<Function>(GV) &&
                      FuncAnnotations.find(GV) != FuncAnnotations.end() &&
-                     (FuncAnnotations.find(GV))->second.startswith("exclude");
+                     (FuncAnnotations.find(GV))->second.starts_with("exclude");
     bool isConstStruct = GV->getSection() != "llvm.metadata" && GV->hasInitializer() && isa<ConstantAggregate>(GV->getInitializer());
     bool isStructOfGlobals = false; // is true if and only if the global variable that we are duplicating contains at least a global pointer
     bool isStructOfFunctions = false; // is true if the global variable that we are duplicating contains at least a global pointer, and such global pointer is a function pointer
@@ -579,7 +584,7 @@ void EDDI::duplicateGlobals(
         auto *valueOperand =storeInst->getValueOperand();
         if(isa<CallBase>(valueOperand)){
           CallBase *callInst = cast<CallBase>(valueOperand);
-          if (callInst->getCalledFunction() && callInst->getCalledFunction()->getName().equals("__cxa_begin_catch"))
+          if (callInst->getCalledFunction() && callInst->getCalledFunction()->getName() == "__cxa_begin_catch")
           {return true;}
         }
         
@@ -822,7 +827,7 @@ int EDDI::duplicateInstruction(
     Callee = getFunctionFromDuplicate(Callee);
     // check if the function call has to be duplicated
     if ((FuncAnnotations.find(Callee) != FuncAnnotations.end() &&
-         (*FuncAnnotations.find(Callee)).second.startswith("to_duplicate")) ||
+         (*FuncAnnotations.find(Callee)).second.starts_with("to_duplicate")) ||
         isIntrinsicToDuplicate(CInstr)) {
       // duplicate the instruction
       cloneInstr(*CInstr, DuplicatedInstructionMap);
@@ -950,6 +955,63 @@ EDDI::duplicateFnArgs(Function &Fn, Module &Md,
 }
 
 /**
+ * REPAIR groups all original instructions first, followed by all their
+ * duplicates, producing the coarse-grain order:
+ *     A, B, C, A_dup, B_dup, C_dup
+ *
+ * This layout increases the temporal and spatial distance between a MI/SI
+ * pair. As a result, a single transient fault (SEU) is less likely to
+ * corrupt both the original and its duplicate before a consistency check
+ * can detect the mismatch (improving error-detection coverage for
+ * spatially-correlated faults)
+ *
+ * The function is called after the EDDI duplication phase has already
+ * cloned every eligible instruction and wired up operands. It only moves
+ * instructions;
+ *
+ * @param BB                The basic block whose instructions are to be
+ *                          reordered
+ * @param ClonedInstructions Set of all instructions that were generated by
+ *                          cloneInstr() during the EDDI duplication phase.
+ *                          Membership in this set distinguishes duplicates
+ *                          from originals
+ */
+void EDDI::repairBasicBlock(
+    BasicBlock &BB,
+    std::unordered_set<Instruction *> &ClonedInstructions) {
+
+  // Collect all duplicated instructions in this BB,
+  // preserving their relative order so that data-flow dependencies
+  // among duplicates remain satisfied after the move
+  std::vector<Instruction *> DupsInOrder;
+
+  for (Instruction &I : BB) {
+    // PHINodes must stay at the top of the block (LLVM invariant).
+    // AllocaInsts are kept in the entry block's alloca region.
+    // Terminators (br, ret, switch, …) must remain last.
+    // None of these should be relocated
+    if (isa<PHINode>(&I) || isa<AllocaInst>(&I) || I.isTerminator())
+      continue;
+
+    // If this instruction belongs to the cloned set, it is a duplicate
+    // that needs to be sunk to the bottom of the block
+    if (ClonedInstructions.count(&I))
+      DupsInOrder.push_back(&I);
+  }
+
+  // If there are no duplicates in this block, nothing to reorder
+  if (DupsInOrder.empty())
+    return;
+
+  // Move every duplicate just before the terminator, in their
+  // original relative order
+  Instruction *InsertPt = BB.getTerminator();
+  for (Instruction *Dup : DupsInOrder) {
+    Dup->moveBefore(InsertPt);
+  }
+}
+
+/**
  * I have to duplicate all instructions except function calls and branches
  * @param Md
  * @return
@@ -1037,6 +1099,7 @@ PreservedAnalyses EDDI::run(Module &Md, ModuleAnalysisManager &AM) {
       tot_funcs++;
     }
   }
+  ClonedInstructions.clear();
   LLVM_DEBUG(dbgs() << "Iterating over the module functions...\n");
   for (Function &Fn : Md) {
     if (shouldCompile(Fn, FuncAnnotations, OriginalFunctions)) {
@@ -1111,6 +1174,9 @@ PreservedAnalyses EDDI::run(Module &Md, ModuleAnalysisManager &AM) {
           }
         }
       }
+      for (BasicBlock &BB : Fn) {
+  repairBasicBlock(BB, ClonedInstructions);
+}
 
       // insert the code for calling the error basic block in case of a mismatch
       IRBuilder<> ErrB(ErrBB);


### PR DESCRIPTION
## PR Title

**Add REPAIR-style coarse-grain duplicate scheduling to EDDI**

## PR Description

### Problem

The original `EDDI` implementation (`EDDI_v1`) duplicates eligible instructions by inserting each clone immediately after its original instruction. This produces a **fine-grain layout** such as:

```text
A, A_dup, B, B_dup, C, C_dup
```

While this preserves the original EDDI duplication flow, it keeps each master instruction and its shadow counterpart very close in the basic block. In this configuration, there is a high probability that a random jump in the code (caused by a bit flip on the program counter, for example) could lead the program to a "balanced" point. In this case, ASPIS wouldn't detect the error because master instructions are coherent with shadow instructions. This is exactly the kind of limitation that motivated the project goal of integrating a REPAIR-style coarse-grain duplication strategy into ASPIS  

---

### Solution

This PR updates the pass by introducing **REPAIR** in `EDDI_v2`.

Instead of leaving duplicates interleaved with their originals, the pass now moves cloned instructions toward the end of each basic block, before the terminator, producing a **coarse-grain layout** of the form:

```text
A, B, C, A_dup, B_dup, C_dup
```

The goal is to increase the temporal/spatial separation between original and duplicate instructions. This is consistent with the REPAIR idea described in the project material and with the broader EDDI discussion on how instruction ordering affects detection behavior.

---

### Main changes

#### 1. Tracking duplicated instructions

`EDDI_v2` introduces a dedicated container to keep track of cloned instructions:

```cpp id="4uegjg"
static std::unordered_set<Instruction *> ClonedInstructions;
```

This set is populated inside `cloneInstr()` whenever a duplicated instruction is emitted into a basic block. This provides an explicit way to distinguish duplicate instructions from original ones during the subsequent repair/reordering phase 

In `EDDI_v1`, duplicated instructions are inserted but not explicitly tracked for later relocation 

---

#### 2. New basic-block repair phase

`EDDI_v2` adds a new function:

```cpp id="d4r3v7"
void EDDI::repairBasicBlock(
    BasicBlock &BB,
    std::unordered_set<Instruction *> &ClonedInstructions)
```

This function scans each basic block, collects duplicated instructions in their original relative order, and moves them before the block terminator.

The implementation explicitly avoids moving terminator instructions.

Keeping duplicates in their original relative order is important to avoid unnecessarily perturbing the shadow computation stream 

This function is not present in `EDDI_v1` 

---

#### 3. Reordering is applied after the standard duplication pipeline

After the pass finishes duplicating instructions in a function, `EDDI_v2` runs the repair phase on every basic block:

```cpp id="9f8jlwm"
for (BasicBlock &BB : Fn) {
  repairBasicBlock(BB, ClonedInstructions);
}
```

This means the new workflow is:

1. duplicate instructions using the existing EDDI logic,
2. duplicate/remap operands as before,
3. preserve all existing checking and transformation logic,
4. finally reorder duplicates into a coarse-grain layout at basic-block level. 

By contrast, `EDDI_v1` ends after duplication and does not perform any post-processing reorder of the duplicated stream 

---

#### 4. Clone-tracking state reset

Before transforming functions, `EDDI_v2` clears the tracking set:

```cpp id="gblshd"
ClonedInstructions.clear();
```

This prevents stale clone metadata from previous transformations from affecting later blocks/functions within the same pass execution 

---

### What remains unchanged

This PR does **not** redesign the full EDDI pass. It intentionally keeps the existing infrastructure intact, including:

* operand duplication,
* consistency-check generation,
* duplicated function argument handling,
* duplicated globals,
* direct/indirect call transformation,
* error basic block generation.

So the key behavioral difference between `EDDI_v1` and `EDDI_v2` is not *what* gets duplicated, but **how duplicated instructions are placed in the basic block** once they have been generated  

---

### Summary

`EDDI_v2` extends the original `EDDI_v1` by adding a REPAIR reordering phase that:

* tracks cloned instructions,
* identifies duplicates inside each basic block,
* groups originals first and duplicates later,
* preserves the rest of the EDDI infrastructure unchanged.
